### PR TITLE
(GH-18) Make provider internal

### DIFF
--- a/src/Cake.Prca.Issues.InspectCode.Tests/InspectCodeProviderFixture.cs
+++ b/src/Cake.Prca.Issues.InspectCode.Tests/InspectCodeProviderFixture.cs
@@ -5,7 +5,7 @@
     using Core.Diagnostics;
     using Testing;
 
-    public class InspectCodeProviderFixture
+    internal class InspectCodeProviderFixture
     {
         public InspectCodeProviderFixture(string fileResourceName)
         {

--- a/src/Cake.Prca.Issues.InspectCode/InspectCodeProvider.cs
+++ b/src/Cake.Prca.Issues.InspectCode/InspectCodeProvider.cs
@@ -11,7 +11,7 @@
     /// <summary>
     /// Provider for code analysis issues reported by JetBrains Inspect Code.
     /// </summary>
-    public class InspectCodeProvider : CodeAnalysisProvider
+    internal class InspectCodeProvider : CodeAnalysisProvider
     {
         private readonly InspectCodeSettings settings;
 


### PR DESCRIPTION
Make `InspectCodeProvider` internal since it only should be called through the alias.

Fixes #18 