### PR TITLE
(GH-21) Remove dependency to Cake.Prca

### DIFF
--- a/nuspec/nuget/Cake.Prca.Issues.InspectCode.nuspec
+++ b/nuspec/nuget/Cake.Prca.Issues.InspectCode.nuspec
@@ -15,9 +15,6 @@
     <copyright>Copyright © 2017 BBT Software AG, Root/Zermatt, Switzerland</copyright>
     <tags>Cake Script PullRequest CodeAnalysis Cake-Prca-IssueProvider Linting InspectCode</tags>
     <releaseNotes>https://github.com/cake-contrib/Cake.Prca.Issues.InspectCode/releases/tag/0.3.0</releaseNotes>
-    <dependencies>
-      <dependency id="Cake.Prca" version="[0.3,0.4)" />
-    </dependencies>
   </metadata>
   <files>
     <file src="Cake.Prca.Issues.InspectCode.dll" target="lib\net45" />


### PR DESCRIPTION
Remove dependency to Cake.Prca

Fixes #21 